### PR TITLE
Fix travis.yml to kick deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,6 @@ jobs:
         provider: script
         script: poetry publish -r mdsol
         skip_cleanup: true
+        on:
+          tags: true
+          all_branches: true


### PR DESCRIPTION
Deployment was skipped... 😞 

> Skipping a deployment with the script provider because this branch is not permitted: 1.1.0

https://travis-ci.com/github/mdsol/mauth-client-python/jobs/340689509#L362

@mdsol/architecture-enablement @jcarres-mdsol 