### PR TITLE
Include ASGI scope root_path in url used to validate mAuth signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.2
+- Fix `MAuthASGIMiddleware` signature validation when the full URL path is split
+  between `root_path` and `path` in the request scope.
+
 # 1.6.1
 - Fix `MAuthWSGIMiddleware` to return a string for "status" and to properly set
   content-length header.

--- a/mauth_client/middlewares/asgi.py
+++ b/mauth_client/middlewares/asgi.py
@@ -38,8 +38,9 @@ class MAuthASGIMiddleware:
         if scope["type"] != "http" or path in self.exempt:
             return await self.app(scope, receive, send)
 
+        root_path = scope["root_path"]
         query_string = scope["query_string"]
-        url = f"{path}?{decode(query_string)}" if query_string else path
+        url = f"{root_path}{path}?{decode(query_string)}" if query_string else f"{root_path}{path}"
         headers = {decode(k): decode(v) for k, v in scope["headers"]}
 
         events, body = await self._get_body(receive)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mauth-client"
-version = "1.6.1"
+version = "1.6.2"
 description = "MAuth Client for Python"
 repository = "https://github.com/mdsol/mauth-client-python"
 authors = ["Medidata Solutions <support@mdsol.com>"]


### PR DESCRIPTION
This fixes an issue encountered with a FastAPI setup similar to the the example provided below. When using a sub application mounted into a parent application the value of `scope["path"]` that the middleware attached to the sub application sees is the path without the prefix the application was mounted at. The route prefix is stored in `scope["root_path"]`. Both need to be combined when creating the URL used for mAuth signature verification.

For example using the application below, for a request to "/subapp/with_auth": `scope["path"]` will be "/with_auth" and `scope["root_path"]` will be "/subapp".

```python
from fastapi import FastAPI
from mauth_client.middlewares import MAuthASGIMiddleware

app = FastAPI()


@app.get("/no_auth")
async def no_auth():
    return {"message": "no auth"}


subapp = FastAPI()
subapp.add_middleware(MAuthASGIMiddleware)


@subapp.get("/with_auth")
async def with_auth():
    return {"message": "with auth"}


app.mount("/subapp", subapp)
```