### PR TITLE
Fixe a use-case when scope path is not set yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.6.4
+- Fix `MAuthASGIMiddleware` when accessing `path` when `path` is not set yet.
+  This appears to only happen on startup.
+- Replace the character `\n` on one-liner private keys.
+
 # 1.6.3
 - Revert change introduced in v1.6.2 now that Starlette has been updated to
   always include `root_path` in `path`.

--- a/mauth_client/lambda_helper.py
+++ b/mauth_client/lambda_helper.py
@@ -20,4 +20,4 @@ def _get_private_key():
         except ModuleNotFoundError:
             pass
 
-    return private_key.replace(" ", "\n").replace("\nRSA\nPRIVATE\nKEY", " RSA PRIVATE KEY")
+    return private_key.replace("\\n", "\n").replace(" ", "\n").replace("\nRSA\nPRIVATE\nKEY", " RSA PRIVATE KEY")

--- a/mauth_client/middlewares/asgi.py
+++ b/mauth_client/middlewares/asgi.py
@@ -33,9 +33,11 @@ class MAuthASGIMiddleware:
     async def __call__(
         self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     ) -> None:
-        path = scope["path"]
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
 
-        if scope["type"] != "http" or path in self.exempt:
+        path = scope["path"]
+        if path in self.exempt:
             return await self.app(scope, receive, send)
 
         query_string = scope["query_string"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mauth-client"
-version = "1.6.3"
+version = "1.6.4"
 description = "MAuth Client for Python"
 repository = "https://github.com/mdsol/mauth-client-python"
 authors = ["Medidata Solutions <support@mdsol.com>"]


### PR DESCRIPTION
This PR also fixes an issue when the private key has `\n` characters, for example, copying a private key from Medistrano and using the insomnia plugin to make it a one-liner.

https://github.com/mdsol/mauth-insomnia-plugin/blob/master/doc/install_guide.md#converting-private-keys

```
"-----BEGIN RSA PRIVATE KEY-----\nMIIEnw...F+H\n-----END RSA PRIVATE KEY-----"
```

Merging this PR will fix this deployment.
https://service.sumologic.com/ui/#/search/create?id=UpyuWYAE1CYLchXGppQNsgwnqeGRCPKzfr7m6jbN
